### PR TITLE
Better device finding

### DIFF
--- a/src/epomakercontroller/cli.py
+++ b/src/epomakercontroller/cli.py
@@ -11,9 +11,6 @@ from epomakercontroller.commands.data.constants import ALL_KEYBOARD_KEYS, Profil
 from epomakercontroller import EpomakerController
 import psutil
 
-# From testing using my own keyboard, this interface works for the controller whilst
-# not interfering with the keyboard's normal operation.
-INTERFACE_NUMBER = 1
 
 @click.group()
 def cli() -> None:
@@ -30,8 +27,7 @@ def upload_image(image_path: str) -> None:
         image_path (str): The path to the image file to upload.
     """
     try:
-        # Need to use interface 0 for this
-        controller = EpomakerController(interface_number=0, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if controller.open_device():
             print("Uploading, you should see the status on the keyboard screen.\n"
                   "The keyboard will be unresponsive during this process.")
@@ -46,22 +42,20 @@ def upload_image(image_path: str) -> None:
 @click.argument("r", type=int)
 @click.argument("g", type=int)
 @click.argument("b", type=int)
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def set_rgb_all_keys(r: int, g: int, b: int, interface: int) -> None:
+def set_rgb_all_keys(r: int, g: int, b: int) -> None:
     """Set RGB colour for all keys.
 
     Args:
         r (int): The red value (0-255).
         g (int): The green value (0-255).
         b (int): The blue value (0-255).
-        interface (int): The HID interface number to use.
     """
     try:
         mapping = EpomakerKeyRGBCommand.KeyMap()
         for key in ALL_KEYBOARD_KEYS:
             mapping[key] = (r, g, b)
         frames = [EpomakerKeyRGBCommand.KeyboardRGBFrame(mapping, 50)]
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if controller.open_device():
             controller.send_keys(frames)
             click.echo(f"All keys set to RGB({r}, {g}, {b}) successfully.")
@@ -71,15 +65,12 @@ def set_rgb_all_keys(r: int, g: int, b: int, interface: int) -> None:
 
 
 @cli.command()
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def cycle_light_modes(interface: int) -> None:
+def cycle_light_modes() -> None:
     """Cycle through the light modes.
 
-    Args:
-        interface (int): The HID interface number to use.
     """
     try:
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if not controller.open_device():
             click.echo("Failed to open device.")
             return
@@ -110,15 +101,12 @@ def cycle_light_modes(interface: int) -> None:
 
 
 @cli.command()
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def send_time(interface: int) -> None:
+def send_time() -> None:
     """Send the current time to the Epomaker device.
 
-    Args:
-        interface (int): The HID interface number to use.
     """
     try:
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if controller.open_device():
             controller.send_time()
             click.echo("Time sent successfully.")
@@ -129,16 +117,14 @@ def send_time(interface: int) -> None:
 
 @cli.command()
 @click.argument("temperature", type=int)
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def send_temperature(temperature: int, interface: int) -> None:
+def send_temperature(temperature: int) -> None:
     """Send temperature to the Epomaker screen.
 
     Args:
         temperature (int): The temperature value in C (0-100).
-        interface (int): The HID interface number to use.
     """
     try:
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if controller.open_device():
             controller.send_temperature(temperature)
             click.echo("Temperature sent successfully.")
@@ -149,16 +135,14 @@ def send_temperature(temperature: int, interface: int) -> None:
 
 @cli.command()
 @click.argument("cpu", type=int)
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def send_cpu(cpu: int, interface: int) -> None:
+def send_cpu(cpu: int) -> None:
     """Send CPU usage percentage to the Epomaker screen.
 
     Args:
         cpu (int): The CPU usage percentage (0-100).
-        interface (int): The HID interface number to use.
     """
     try:
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if controller.open_device():
             controller.send_cpu(cpu)
             click.echo("CPU usage sent successfully.")
@@ -169,16 +153,14 @@ def send_cpu(cpu: int, interface: int) -> None:
 
 @cli.command()
 @click.argument("temp_key", type=str, required=False)
-@click.option("-i", "--interface", type=int, default=INTERFACE_NUMBER)
-def start_daemon(temp_key: str | None, interface: int) -> None:
+def start_daemon(temp_key: str | None) -> None:
     """Start a daemon to update the CPU usage and optionally a temperature.
 
     Args:
         temp_key (str): A label corresponding to the device to monitor.
-        interface (int): The HID interface number to use.
     """
     try:
-        controller = EpomakerController(interface, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         first = True
         while True:
             if not controller.open_device():
@@ -256,14 +238,14 @@ def dev(print_info: bool, generate_udev: bool) -> None:
     """
     if print_info:
         click.echo("Printing all available information about the connected keyboard.")
-        controller = EpomakerController(INTERFACE_NUMBER, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if not controller.open_device(only_info=True):
             click.echo("Failed to open device.")
             return
     elif generate_udev:
         click.echo("Generating udev rule for the connected keyboard.")
         # Init controller to get the PID
-        controller = EpomakerController(INTERFACE_NUMBER, dry_run=False)
+        controller = EpomakerController(dry_run=False)
         if not controller.open_device(only_info=True):
             click.echo("Failed to open device.")
             return

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -53,18 +53,15 @@ class EpomakerController:
 
     def __init__(
         self,
-        interface_number: int,
         vendor_id: int = VENDOR_ID,
         dry_run: bool = True,
     ) -> None:
         """Initializes the EpomakerController object.
 
         Args:
-            interface_number (int): The interface number of the USB HID device to use.
             vendor_id (int): The vendor ID of the USB HID device.
             dry_run (bool): Whether to run in dry run mode (default: True).
         """
-        self.interface_number = interface_number
         self.vendor_id = vendor_id
         self.device = hid.device()
         self.dry_run = dry_run
@@ -103,12 +100,8 @@ class EpomakerController:
         # This way we don't block usage of the keyboard whilst the device is open
         device_path = self._find_device_path()
         if device_path is None:
-            available_devices = [
-                device["interface_number"] for device in self.device_list
-            ]
             raise ValueError(
-                f"No device found with interface number {self.interface_number}\n"
-                f"Available devices: {available_devices}"
+                "No device found"
             )
         self._open_device(device_path)
 


### PR DESCRIPTION
I have removed any need to use hid interface numbers

Now instead the controller checks in "/sys/class/input" for any events that have names like "ROYUAN .* System Control", and then works out the hid path

Hopefully this will actually simplify things since it goes and finds the correct path without the user having to specify an interface number