### PR TITLE
enh: Prints vendor and product ids as hex.

### DIFF
--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -6,6 +6,7 @@ for an Epomaker USB HID device.
 
 import dataclasses
 from datetime import datetime
+from json import dumps
 import os
 import time
 from typing import Any, Optional
@@ -170,9 +171,17 @@ class EpomakerController:
 
     def _print_device_info(self) -> None:
         """Prints device information."""
-        import pprint
-
-        pprint.pprint(self.device_list)
+        devices = self.device_list.copy()
+        for device in devices:
+            device["path"] = device["path"].decode("utf-8")
+            device["vendor_id"] = f"0x{device["vendor_id"]:2x}"
+            device["product_id"] = f"0x{device["product_id"]:2x}"
+        print(
+            dumps(
+                devices,
+                indent="  ",
+            )
+        )
 
     @dataclasses.dataclass
     class HIDInfo:


### PR DESCRIPTION
This changes the `dev --print` command to print USB product and vendor IDs in hex values, to match the way the IDs are represented in the code and common tools like `lsusb`.

After this change:
```
[
  {
    "path": "3-7:1.0",
    "vendor_id": "0x3151",
    "product_id": "0x4015",
    "serial_number": "",
    "release_number": 261,
    "manufacturer_string": "ROYUAN",
    "product_string": "Gaming Keyboard",
    "usage_page": 0,
    "usage": 0,
    "interface_number": 0,
    "bus_type": 1
  },
  {
    "path": "3-7:1.1",
    "vendor_id": "0x3151",
    "product_id": "0x4015",
    "serial_number": "",
    "release_number": 261,
    "manufacturer_string": "ROYUAN",
    "product_string": "Gaming Keyboard",
    "usage_page": 0,
    "usage": 0,
    "interface_number": 1,
    "bus_type": 1
  },
  {
    "path": "3-7:1.2",
    "vendor_id": "0x3151",
    "product_id": "0x4015",
    "serial_number": "",
    "release_number": 261,
    "manufacturer_string": "ROYUAN",
    "product_string": "Gaming Keyboard",
    "usage_page": 0,
    "usage": 0,
    "interface_number": 2,
    "bus_type": 1
  }
]
```

Before:
```
[{'bus_type': 1,
  'interface_number': 0,
  'manufacturer_string': 'ROYUAN',
  'path': b'3-7:1.0',
  'product_id': 16405,
  'product_string': 'Gaming Keyboard',
  'release_number': 261,
  'serial_number': '',
  'usage': 0,
  'usage_page': 0,
  'vendor_id': 12625},
 {'bus_type': 1,
  'interface_number': 1,
  'manufacturer_string': 'ROYUAN',
  'path': b'3-7:1.1',
  'product_id': 16405,
  'product_string': 'Gaming Keyboard',
  'release_number': 261,
  'serial_number': '',
  'usage': 0,
  'usage_page': 0,
  'vendor_id': 12625},
 {'bus_type': 1,
  'interface_number': 2,
  'manufacturer_string': 'ROYUAN',
  'path': b'3-7:1.2',
  'product_id': 16405,
  'product_string': 'Gaming Keyboard',
  'release_number': 261,
  'serial_number': '',
  'usage': 0,
  'usage_page': 0,
  'vendor_id': 12625}]
```

Note that the above output is for an Epomaker EP64 keyboard.