### PR TITLE
fix: Fixes Github Actions pytest and reformat hex.

### DIFF
--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -174,8 +174,8 @@ class EpomakerController:
         devices = self.device_list.copy()
         for device in devices:
             device["path"] = device["path"].decode("utf-8")
-            device["vendor_id"] = f"0x{device["vendor_id"]:2x}"
-            device["product_id"] = f"0x{device["product_id"]:2x}"
+            device["vendor_id"] = f"0x{device['vendor_id']:04x}"
+            device["product_id"] = f"0x{device['product_id']:04x}"
         print(
             dumps(
                 devices,


### PR DESCRIPTION
For some reason this works locally but not when github actions runs pytest, so this tiny change fixes the string interpolation.

Also the hex strings should of course have been zero padded 4 digit hex values.