### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y \
+    python3-tk \
+    udev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+WORKDIR /src
+
+RUN pip install .
+
+RUN useradd -ms /bin/bash nonrootuser && chown -R nonrootuser:nonrootuser /src
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  epomaker-controller:
+    image: epomaker-controller
+    privileged: true            # Allows access to USB and other host devices
+    volumes:
+      - /dev/bus/usb:/dev/bus/usb
+      - /run/udev:/run/udev
+    stdin_open: true
+    tty: true
+    command: /bin/bash
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,10 @@
-version: '3'
 services:
   epomaker-controller:
     image: epomaker-controller
+    build: .
     privileged: true            # Allows access to USB and other host devices
     volumes:
       - /dev/bus/usb:/dev/bus/usb
       - /run/udev:/run/udev
     stdin_open: true
     tty: true
-    command: /bin/bash
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-# Apply epomaker udev rules
-epomakercontroller dev --udev
+# Apply epomaker udev rules if necessary
+if [ ! -f /etc/udev/rules.d/99-epomaker-rt100.rules ]; then
+    epomakercontroller dev --udev >/dev/null 2>&1
+fi
 
-# Switch to non-root user to run the application
-exec su - nonrootuser -s /bin/bash
+APP_ARGS="$@"
+
+# Switch to non-root user and execute the application with the passed arguments
+exec su - nonrootuser -c "epomakercontroller $APP_ARGS"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Apply epomaker udev rules
+epomakercontroller dev --udev
+
+# Switch to non-root user to run the application
+exec su - nonrootuser -s /bin/bash

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -160,12 +160,21 @@ class EpomakerController:
         with open(temp_file_path, "w") as temp_file:
             temp_file.write(rule_content)
 
-        # Move the file to the correct location using sudo
-        subprocess.run(["sudo", "mv", temp_file_path, rule_file_path], check=True)
+        # Move the file to the correct location, reload rules
 
-        # Reload udev rules
-        subprocess.run(["sudo", "udevadm", "control", "--reload-rules"], check=True)
-        subprocess.run(["sudo", "udevadm", "trigger"], check=True)
+        move_command = ["mv", temp_file_path, rule_file_path]
+        reload_command = ["udevadm", "control", "--reload-rules"]
+        trigger_command = ["udevadm", "trigger"]
+
+        if os.geteuid() != 0:
+            # Use sudo if not root
+            move_command = ["sudo"] + move_command
+            reload_command = ["sudo"] + reload_command
+            trigger_command = ["sudo"] + trigger_command
+
+        subprocess.run(move_command, check=True)
+        subprocess.run(reload_command, check=True)
+        subprocess.run(trigger_command, check=True)
 
         print("Rule generated successfully")
 


### PR DESCRIPTION
Add a Dockerfile and a compose file to use the application containerized.

The Dockerfile copies the source and installs it using pip. Then a nonrootuser is created for running the application later on.

I am using an entrypoint.sh script so that the container runs `epomakercontroller --dev udev` when it starts up, then drops down to the nonrootuser passing any cli args along to `epomakercontroller`.

To get the udev rules to work I had to mount /run/udev in the compose file, which I don't love doing since I quite want the container to be isolated, however I'd prefer to run `epomakercontroller` as non-root, which requires udev rules, which requires mounting /run/udev.

I am not sure how this would ever work with uploading an image but I'll look into that. I am mostly hoping to use this with users who are experiencing problems so we can rule out environment to some extent.


Use compose to build it:
`docker compose build`

Then run with some commands using compose run:
`docker compose run epomaker-controller <some commands>`
eg
`docker compose run epomaker-controller send-cpu 56`
