### PR TITLE
Use a config file for some of the controller settings

### DIFF
--- a/src/epomakercontroller/cli.py
+++ b/src/epomakercontroller/cli.py
@@ -10,19 +10,14 @@ from .commands import (
     EpomakerProfileCommand,
 )
 from .commands.data.constants import Profile
-from .configs.configs import Config, ConfigType
+from .configs.configs import ConfigType, get_all_configs
 from .epomakercontroller import EpomakerController
 from .epomaker_utils import get_cpu_usage, get_device_temp, print_temp_devices
 from .keyboard_keys import KeyboardKeys
 from .keyboard_gui import RGBKeyboardGUI
 
-DEFAULT_LAYOUT="EpomakerRT100-UK-ISO.json"
-DEFAULT_KEYMAPS="EpomakerRT100.json"
+CONFIGS = get_all_configs()
 
-CONFIGS = {
-    ConfigType.CONF_LAYOUT : Config(ConfigType.CONF_LAYOUT, DEFAULT_LAYOUT),
-    ConfigType.CONF_KEYMAP : Config(ConfigType.CONF_KEYMAP, DEFAULT_KEYMAPS),
-}
 
 @click.group()
 def cli() -> None:
@@ -39,7 +34,7 @@ def upload_image(image_path: str) -> None:
         image_path (str): The path to the image file to upload.
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if controller.open_device():
             print("Uploading, you should see the status on the keyboard screen.\n"
                   "The keyboard will be unresponsive during this process.")
@@ -68,7 +63,7 @@ def set_rgb_all_keys(r: int, g: int, b: int) -> None:
         for key in keyboard_keys:
             mapping[key] = (r, g, b)
         frames = [EpomakerKeyRGBCommand.KeyboardRGBFrame(key_map=mapping)]
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if controller.open_device():
             controller.send_keys(frames)
             click.echo(f"All keys set to RGB({r}, {g}, {b}) successfully.")
@@ -83,7 +78,7 @@ def cycle_light_modes() -> None:
 
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if not controller.open_device():
             click.echo("Failed to open device.")
             return
@@ -119,7 +114,7 @@ def send_time() -> None:
 
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if controller.open_device():
             controller.send_time()
             click.echo("Time sent successfully.")
@@ -137,7 +132,7 @@ def send_temperature(temperature: int) -> None:
         temperature (int): The temperature value in C (0-100).
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if controller.open_device():
             controller.send_temperature(temperature)
             click.echo("Temperature sent successfully.")
@@ -155,7 +150,7 @@ def send_cpu(cpu: int) -> None:
         cpu (int): The CPU usage percentage (0-100).
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if controller.open_device():
             controller.send_cpu(cpu)
             click.echo("CPU usage sent successfully.")
@@ -174,7 +169,7 @@ def start_daemon(temp_key: str | None, test_mode: bool) -> None:
         temp_key (str): A label corresponding to the device to monitor.
     """
     try:
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if not controller.open_device():
             click.echo("Failed to open device.")
             return
@@ -218,14 +213,14 @@ def dev(print_info: bool, generate_udev: bool) -> None:
     """
     if print_info:
         click.echo("Printing all available information about the connected keyboard.")
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if not controller.open_device(only_info=True):
             click.echo("Failed to open device.")
             return
     elif generate_udev:
         click.echo("Generating udev rule for the connected keyboard.")
         # Init controller to get the PID
-        controller = EpomakerController(dry_run=False)
+        controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
         if not controller.open_device(only_info=True):
             click.echo("Failed to open device.")
             return
@@ -239,7 +234,7 @@ def set_keys() -> None:
     """Open a simple GUI to set individual key colours.
 
     """
-    controller = EpomakerController(dry_run=False)
+    controller = EpomakerController(CONFIGS[ConfigType.CONF_MAIN], dry_run=False)
     if not controller.open_device():
         click.echo("Failed to open device.")
         return

--- a/src/epomakercontroller/commands/EpomakerKeyRGBCommand.py
+++ b/src/epomakercontroller/commands/EpomakerKeyRGBCommand.py
@@ -8,8 +8,6 @@ keyboard.
 from dataclasses import dataclass
 from typing import Iterator
 
-from epomakercontroller.configs.configs import Config
-
 from .EpomakerCommand import EpomakerCommand, CommandStructure
 from ..keyboard_keys import KeyboardKeys, KeyboardKey
 from .reports.Report import Report, BUFF_LENGTH

--- a/src/epomakercontroller/configs/configs.py
+++ b/src/epomakercontroller/configs/configs.py
@@ -1,29 +1,151 @@
 from dataclasses import dataclass
 from enum import Enum
 import json
+import os
+from pathlib import Path
+from typing import Any
 
 import epomakercontroller.configs.configs
 import epomakercontroller.configs.layouts
 import epomakercontroller.configs.keymaps
 import importlib.resources as pkg_resources
 
+
 class ConfigType(Enum):
-    CONF_LAYOUT = 0
-    CONF_KEYMAP = 1
+    CONF_MAIN = 0
+    CONF_LAYOUT = 1
+    CONF_KEYMAP = 2
+
+
+DEFAULT_MAIN_CONFIG = {
+    "VENDOR_ID": 0x3151,
+    "PRODUCT_IDS_WIRED": [0x4010, 0x4015],
+    "PRODUCT_IDS_24G" : [0x4011, 0x4016],
+    "USE_WIRELESS": False,
+    "DEVICE_DESCRIPTION_REGEX": "ROYUAN .* System Control",
+    # The file will be looked for in the install location first, otherwise use a full filepath
+    "CONF_LAYOUT_PATH": "EpomakerRT100-UK-ISO.json",
+    "CONF_KEYMAP_PATH": "EpomakerRT100.json",
+}
+
 
 @dataclass
 class Config:
     type: ConfigType
-    filename: str
+    filename: str | None = None
+    data: dict[Any, Any] | None = None
 
     def __post_init__(self) -> None:
-        config_path = None
-        if self.type == ConfigType.CONF_LAYOUT:
-            with pkg_resources.path(epomakercontroller.configs.layouts, self.filename) as path:
-                config_path = str(path)
-        elif self.type == ConfigType.CONF_KEYMAP:
-            with pkg_resources.path(epomakercontroller.configs.keymaps, self.filename) as path:
-                config_path = str(path)
+        if self.filename:
+            with open(self._find_config_path(self.filename, self.type), "r") as f:
+                self.data = json.load(f)
+                return
 
-        with open(config_path, "r") as f:
-            self.data = json.load(f)
+        assert self.data is not None, "ERROR: Config has no data"
+
+    @staticmethod
+    def _find_config_path(filename: str, type: ConfigType) -> str:
+        # If the filename exists, use that
+        if os.path.exists(filename):
+            return os.path.realpath(filename)
+
+        # Otherwise check for installed files
+        if type == ConfigType.CONF_LAYOUT:
+            with pkg_resources.path(epomakercontroller.configs.layouts, filename) as path:
+                return str(path)
+        elif type == ConfigType.CONF_KEYMAP:
+            with pkg_resources.path(epomakercontroller.configs.keymaps, filename) as path:
+                return str(path)
+
+        raise AttributeError(f"Unsupported ConfigType: {type.name}")
+
+    def __getitem__(self, key: str) -> Any:
+        assert self.data is not None, "ERROR: Config has no data"
+        if key not in self.data:
+            print(f"Key {key} not found in {self.type.name}")
+            return None
+        return self.data[key]
+
+
+def get_main_config_directory() -> Path:
+    home_dir = Path.home()
+    config_dir = home_dir / ".epomaker-controller"
+    return config_dir
+
+
+def create_default_main_config(config_file: Path) -> None:
+    with open(config_file, 'w') as f:
+        json.dump(DEFAULT_MAIN_CONFIG, f, indent=4)
+
+
+def save_main_config(config: Config) -> None:
+    config_dir = get_main_config_directory()
+    config_file = config_dir / "config.json"
+    with open(config_file, 'w') as f:
+        json.dump(config.data, f, indent=4)
+
+
+def setup_main_config() -> Path:
+    config_dir = get_main_config_directory()
+    config_file = config_dir / "config.json"
+
+    # Create the config directory if it doesn't exist
+    if not config_dir.exists():
+        print(f"Creating config directory at {config_dir}")
+        config_dir.mkdir(parents=True)
+
+    # Create the default config file if it doesn't exist
+    if not config_file.exists():
+        print(f"Creating default config file at {config_file}")
+        create_default_main_config(config_file)
+    else:
+        print(f"Config file already exists at {config_file}")
+
+    return config_file
+
+
+def verify_main_config(in_config: Config) -> Config:
+    assert in_config.type == ConfigType.CONF_MAIN, "ERROR: verify_main_config only for Configs of type CONF_MAIN"
+    assert in_config.data is not None, "ERROR: Config has no data"
+
+    # Ensure no unsupported entries are present
+    extra_keys = set(in_config.data.keys()) - set(DEFAULT_MAIN_CONFIG.keys())
+    if extra_keys:
+        raise ValueError(f"ERROR: Unsupported config entries found: {extra_keys}")
+
+    # Merge the default values with the provided config, ensuring no missing keys
+    out_config = Config(
+        type=in_config.type,
+        data={**DEFAULT_MAIN_CONFIG, **in_config.data}
+    )
+
+    # Write config back
+    save_main_config(out_config)
+
+    return out_config
+
+
+def load_main_config() -> Config:
+    config_file = setup_main_config()
+
+    config = Config(ConfigType.CONF_MAIN, config_file.as_posix())
+
+    return verify_main_config(config)
+
+
+def get_all_configs() -> dict[ConfigType, Config]:
+    # First load the main config file
+    main_config = load_main_config()
+    assert main_config.data is not None, "ERROR: Config has no data"
+
+    # Use keyboard and layout configs as per main config
+    conf_layout_path = main_config.data["CONF_LAYOUT_PATH"]
+    conf_keymap_path = main_config.data["CONF_KEYMAP_PATH"]
+
+    all_configs = {
+        ConfigType.CONF_MAIN : main_config,
+        ConfigType.CONF_LAYOUT : Config(ConfigType.CONF_LAYOUT, conf_layout_path),
+        ConfigType.CONF_KEYMAP : Config(ConfigType.CONF_KEYMAP, conf_keymap_path)
+    }
+
+    return all_configs

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -25,16 +25,7 @@ from .commands import (
     EpomakerKeyRGBCommand,
 )
 from .commands.data.constants import BUFF_LENGTH
-
-VENDOR_ID = 0x3151
-# Some Epomaker keyboards seem to have have different product IDs
-PRODUCT_IDS_WIRED = [0x4010, 0x4015]
-PRODUCT_IDS_24G = [0x4011, 0x4016]
-
-USE_WIRELESS = False
-PRODUCT_IDS = PRODUCT_IDS_WIRED
-if USE_WIRELESS:
-    PRODUCT_IDS += PRODUCT_IDS_24G
+from .configs.configs import Config
 
 
 class EpomakerController:
@@ -56,7 +47,7 @@ class EpomakerController:
 
     def __init__(
         self,
-        vendor_id: int = VENDOR_ID,
+        config_main : Config,
         dry_run: bool = True,
     ) -> None:
         """Initializes the EpomakerController object.
@@ -65,7 +56,11 @@ class EpomakerController:
             vendor_id (int): The vendor ID of the USB HID device.
             dry_run (bool): Whether to run in dry run mode (default: True).
         """
-        self.vendor_id = vendor_id
+        self.config_main = config_main
+        self.vendor_id = config_main["VENDOR_ID"]
+        self.use_wireless = config_main["USE_WIRELESS"]
+        self.product_ids: list[int] = config_main["PRODUCT_IDS_WIRED"] if not self.use_wireless else config_main["PRODUCT_IDS_24G"]
+        self.device_description = config_main["DEVICE_DESCRIPTION_REGEX"]
         self.device = hid.device()
         self.dry_run = dry_run
         self.device_list: list[dict[str, Any]] = []
@@ -133,7 +128,7 @@ class EpomakerController:
         Returns:
             int | None: The product ID if found, None otherwise.
         """
-        for pid in PRODUCT_IDS:
+        for pid in self.product_ids:
             self.device_list = hid.enumerate(self.vendor_id, pid)
             if self.device_list:
                 return pid
@@ -217,24 +212,22 @@ class EpomakerController:
         event_path: str
         hid_path: Optional[str] = None
 
-    @staticmethod
-    def _find_device_path() -> Optional[bytes]:
+    def _find_device_path(self) -> Optional[bytes]:
         """Finds the device path with the specified interface number.
 
         Returns:
             Optional[bytes]: The device path if found, None otherwise.
         """
-        description = r"ROYUAN .* System Control"
         input_dir = "/sys/class/input"
-        hid_infos = EpomakerController._get_hid_infos(input_dir, description)
+        hid_infos = EpomakerController._get_hid_infos(input_dir, self.device_description)
 
         if not hid_infos:
-            print(f"No events found with description: '{description}'")
+            print(f"No events found with description: '{self.device_description}'")
             return None
 
         EpomakerController._populate_hid_paths(hid_infos)
 
-        return EpomakerController._select_device_path(hid_infos)
+        return self._select_device_path(hid_infos)
 
     @staticmethod
     def _get_hid_infos(input_dir: str, description: str) -> list[HIDInfo]:
@@ -268,10 +261,9 @@ class EpomakerController:
             match = re.search(r"\b\d+-[\d.]+:\d+\.\d+\b", hid_device_path)
             hi.hid_path = match.group(0) if match else None
 
-    @staticmethod
-    def _select_device_path(hid_infos: list[HIDInfo]) -> Optional[bytes]:
+    def _select_device_path(self, hid_infos: list[HIDInfo]) -> Optional[bytes]:
         """Select the appropriate device path based on interface preference."""
-        device_name_filter = "Wireless" if USE_WIRELESS else "Wired"
+        device_name_filter = "Wireless" if self.use_wireless else "Wired"
         filtered_devices = [h for h in hid_infos if device_name_filter in h.device_name]
 
         if not filtered_devices:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,20 +18,13 @@ import numpy as np
 import matplotlib.pyplot as plt  # type: ignore
 import cv2
 
-from epomakercontroller.configs.configs import Config, ConfigType
+from epomakercontroller.configs.configs import ConfigType, get_all_configs
 from epomakercontroller.keyboard_keys import KeyboardKeys
 
 # Set to True to display images
 DISPLAY = False
 
-
-DEFAULT_LAYOUT="EpomakerRT100-UK-ISO.json"
-DEFAULT_KEYMAPS="EpomakerRT100.json"
-
-CONFIGS = {
-    ConfigType.CONF_LAYOUT : Config(ConfigType.CONF_LAYOUT, DEFAULT_LAYOUT),
-    ConfigType.CONF_KEYMAP : Config(ConfigType.CONF_KEYMAP, DEFAULT_KEYMAPS),
-}
+CONFIGS = get_all_configs()
 
 
 @pytest.fixture


### PR DESCRIPTION
A basic config file will be read from $HOME/epomaker-controller/config.json which looks like:
```json
{
    "VENDOR_ID": 12625,
    "PRODUCT_IDS_WIRED": [
        16400,
        16405
    ],
    "PRODUCT_IDS_24G": [
        16401,
        16406
    ],
    "USE_WIRELESS": false,
    "CONF_LAYOUT_PATH": "EpomakerRT100-UK-ISO.json",
    "CONF_KEYMAP_PATH": "EpomakerRT100.json",
    "DEVICE_DESCRIPTION_REGEX": "ROYUAN .* System Control"
}
```
If it doesn't exist on startup one will be created.

The files for CON_* will be looked for in an installed location, but can also be full filepaths to other config files for layout and keymap