### PR TITLE
Config file encoding

### DIFF
--- a/src/epomakercontroller/configs/configs.py
+++ b/src/epomakercontroller/configs/configs.py
@@ -38,7 +38,7 @@ class Config:
     def __post_init__(self) -> None:
         # If data not set manually, load it from the filename
         if not self.data:
-            with open(self._find_config_path(self.filename, self.type), "r") as f:
+            with open(self._find_config_path(self.filename, self.type), "r", encoding="utf-8") as f:
                 self.data = json.load(f)
                 return
 
@@ -75,14 +75,14 @@ def get_main_config_directory() -> Path:
 
 
 def create_default_main_config(config_file: Path) -> None:
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding="utf-8") as f:
         json.dump(DEFAULT_MAIN_CONFIG, f, indent=4)
 
 
 def save_main_config(config: Config) -> None:
     config_dir = get_main_config_directory()
     config_file = config_dir / "config.json"
-    with open(config_file, 'w') as f:
+    with open(config_file, 'w', encoding="utf-8") as f:
         json.dump(config.data, f, indent=4)
 
 

--- a/src/epomakercontroller/configs/configs.py
+++ b/src/epomakercontroller/configs/configs.py
@@ -99,8 +99,6 @@ def setup_main_config() -> Path:
     if not config_file.exists():
         print(f"Creating default config file at {config_file}")
         create_default_main_config(config_file)
-    else:
-        print(f"Config file already exists at {config_file}")
 
     return config_file
 

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -198,7 +198,7 @@ class EpomakerController:
 
         # Write the rule to a temporary file
         temp_file_path = "/tmp/99-epomaker-rt100.rules"
-        with open(temp_file_path, "w") as temp_file:
+        with open(temp_file_path, "w", encoding="utf-8") as temp_file:
             temp_file.write(rule_content)
 
         # Move the file to the correct location, reload rules
@@ -264,7 +264,7 @@ class EpomakerController:
             if event.startswith("event"):
                 device_name_path = os.path.join(input_dir, event, "device", "name")
                 try:
-                    with open(device_name_path, "r") as f:
+                    with open(device_name_path, "r", encoding="utf-8") as f:
                         device_name = f.read().strip()
                         if re.search(description, device_name):
                             event_path = os.path.join(input_dir, event)


### PR DESCRIPTION
Bug found in https://github.com/strodgers/epomaker-controller/issues/46

The file encoding should be specified whenever there's a read or write

Have also removed the printout when a main config file is found eg:
```
$ Config file already exists at <location>
```
This was only ever to ensure a config file was being used, it doesn't need to be printed out all the time.