### PR TITLE
Use a time helper class to ensure delays between sending commands

### DIFF
--- a/src/epomakercontroller/cli.py
+++ b/src/epomakercontroller/cli.py
@@ -155,7 +155,7 @@ def start_daemon(temp_key: str | None, test_mode: bool) -> None:
     except KeyboardInterrupt:
         click.echo("Daemon interrupted by user.")
     except Exception as e:
-        click.echo(f"Failed to start daemon: {e}")
+        click.echo(f"Error in start-daemon: {e}")
     controller.close_device()
 
 

--- a/src/epomakercontroller/utils/time_helper.py
+++ b/src/epomakercontroller/utils/time_helper.py
@@ -1,0 +1,24 @@
+import time
+
+
+class TimeHelper:
+    """
+    A helper class to ensure a minimum amount of time has passed between its creation and deletion.
+
+    This class starts a timer when it is initialized. When it is deleted, it calculates the total
+    elapsed time and enforces a delay to ensure that the specified minimum time has passed.
+
+    Args:
+        min_duration (float): The minimum total duration (in seconds) that should pass between the
+                              creation and deletion of the instance.
+    """
+    def __init__(self, min_duration: float) -> None:
+        self.min_duration = min_duration
+        self.start_time = time.time()
+
+    def __del__(self) -> None:
+        elapsed_time = time.time() - self.start_time
+        remaining_time = self.min_duration - elapsed_time
+        # Ensure we do not sleep for a negative amount of time
+        if remaining_time > 0:
+            time.sleep(remaining_time)


### PR DESCRIPTION
Add a `TimeHelper` class that will ensure some preset delay is waited for when executing a command.

I measured how fast the keyboard seems to be able to respond to temp/cpu changes to be around 1.6 seconds, so ensure this amount of time is waited.