### PR TITLE
Trying to call get_feature_report causes crash

### DIFF
--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -190,10 +190,6 @@ class EpomakerController:
         print("Device opened, initializing..")
         for report in set_reports:
             self.device.send_feature_report(report)
-            report_id = report[0]  # Use the first byte of each report as report_id
-            self.device.get_feature_report(
-                report_id, get_report_size
-            )  # Ignore response
         print("... Done!")
 
     def generate_udev_rule(self) -> None:


### PR DESCRIPTION
This was added in because I thought maybe getting a response would be required after sending a feature report.

On some machines everything seems to work fine, but other times this call to `get_feature_report` results in a read error.

It's not used for anything, so just get rid of it