### PR TITLE
Dont sent init data

### DIFF
--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -170,28 +170,6 @@ class EpomakerController:
 
         assert self.device is not None
 
-        # Do some initialization, just copied from what official software does
-        set_reports = [
-            [0xFD] + [0x00] * 127,
-            [0x8F] + [0x00] * 3 + [0x70] + [0x00] * 123,
-            [0x87] + [0x00] * 3 + [0x78] + [0x00] * 123,
-            [0x80] + [0x00] * 3 + [0x7F] + [0x00] * 123,
-            [0xAD] + [0x00] * 3 + [0x52] + [0x00] * 123,
-            [0x84] + [0x00] * 3 + [0x7B] + [0x00] * 123,
-            [0x85] + [0x00] * 3 + [0x7A] + [0x00] * 123,
-            [0x87] + [0x00] * 3 + [0x78] + [0x00] * 123,
-            [0x86] + [0x00] * 3 + [0x79] + [0x00] * 123,
-            [0x91] + [0x00] * 3 + [0x6E] + [0x00] * 123,
-            [0x92] + [0x00] * 3 + [0x6D] + [0x00] * 123,
-            [0x97] + [0x00] * 3 + [0x68] + [0x00] * 123,
-        ]
-        get_report_size = 64
-
-        print("Device opened, initializing..")
-        for report in set_reports:
-            self.device.send_feature_report(report)
-        print("... Done!")
-
     def generate_udev_rule(self) -> None:
         """Generates a udev rule for the connected keyboard."""
         rule_content = (


### PR DESCRIPTION
Same thing as https://github.com/strodgers/epomaker-controller/pull/58

This removes some code that was trying to mimic the windows driver by sending some data on startup. Even though this didnt seem to cause any problems on one machine, on another it causes the systems control interface to crash and not come back