### PR TITLE
Add supported image formats

### DIFF
--- a/src/epomakercontroller/commands/EpomakerImageCommand.py
+++ b/src/epomakercontroller/commands/EpomakerImageCommand.py
@@ -1,5 +1,6 @@
 """Command for sending images to the Epomaker keyboard."""
 
+import os
 import cv2
 import numpy as np
 
@@ -8,6 +9,7 @@ from .data.constants import IMAGE_DIMENSIONS
 from .reports.Report import Report, BUFF_LENGTH
 from .reports.ReportWithData import ReportWithData
 
+SUPPORTED_FORMATS = [".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif", ".webp"]
 
 class EpomakerImageCommand(EpomakerCommand):
     """A command for sending images to the keyboard."""
@@ -67,7 +69,10 @@ class EpomakerImageCommand(EpomakerCommand):
         Args:
             image_path (str): The path to the image file.
         """
+        _, extension = os.path.splitext(image_path)
+        assert extension in SUPPORTED_FORMATS, f"Unsupported format\nSupported formats are: {SUPPORTED_FORMATS}"
         image = cv2.imread(image_path)
+        assert not isinstance(image, type(None)), f"Failed reading {image_path}"
         image = cv2.resize(image, IMAGE_DIMENSIONS)
         image = cv2.flip(image, 0)
         image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -276,7 +276,7 @@ def test_encode_image_formats() -> None:
     # Create a dummy 10x10 image for testing
     dummy_img = np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
 
-    temp_directory = tempfile.TemporaryDirectory(delete=True)
+    temp_directory = tempfile.TemporaryDirectory()
     for fmt in supported_formats:
         output_path = os.path.join(temp_directory.name, f"test_image.{fmt}")
         success = cv2.imwrite(output_path, dummy_img)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,7 @@ import cv2
 
 from epomakercontroller.configs.configs import ConfigType, get_all_configs
 from epomakercontroller.utils.keyboard_keys import KeyboardKeys
+from epomakercontroller.commands.EpomakerImageCommand import SUPPORTED_FORMATS
 
 # Set to True to display images
 DISPLAY = False
@@ -271,13 +272,11 @@ def test_encode_image_command() -> None:
 
 
 def test_encode_image_formats() -> None:
-    supported_formats = ["png", "jpg", "jpeg", "bmp", "tiff", "tif", "webp"]
-
     # Create a dummy 10x10 image for testing
     dummy_img = np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
 
     temp_directory = tempfile.TemporaryDirectory()
-    for fmt in supported_formats:
+    for fmt in SUPPORTED_FORMATS:
         output_path = os.path.join(temp_directory.name, f"test_image.{fmt}")
         success = cv2.imwrite(output_path, dummy_img)
         assert success, f"Failed to save: {output_path}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 """Test cases for the __main__ module."""
 
+import os
+import tempfile
 import pytest
 from click.testing import CliRunner
 from typing import Iterator, Iterable
@@ -266,6 +268,22 @@ def test_encode_image_command() -> None:
 
         assert np.all(np.array(difference) <= 8)
         i += 1
+
+
+def test_encode_image_formats() -> None:
+    supported_formats = ["png", "jpg", "jpeg", "bmp", "tiff", "tif", "webp"]
+
+    # Create a dummy 10x10 image for testing
+    dummy_img = np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
+
+    temp_directory = tempfile.TemporaryDirectory(delete=True)
+    for fmt in supported_formats:
+        output_path = os.path.join(temp_directory.name, f"test_image.{fmt}")
+        success = cv2.imwrite(output_path, dummy_img)
+        assert success, f"Failed to save: {output_path}"
+
+        command = EpomakerImageCommand.EpomakerImageCommand()
+        command.encode_image(output_path)
 
 
 def test_checksum() -> None:


### PR DESCRIPTION
Related: https://github.com/strodgers/epomaker-controller/issues/57

OpenCV is only happy with certain image formats, so check before trying to upload.

I manually checked the ones listed in `SUPPORTED_FORMATS`, also added a unit test for encoding them