### PR TITLE
Individual sensor keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ numpy = "<2.0"
 opencv-python-headless = "==4.10.0.82"
 psutil = ">=6.0.0"
 python-dateutil = "==2.8.2"
+gpustat = ">=1.1.1"
 
 [tool.poetry.dev-dependencies]
 matplotlib = "==3.5.3"

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -461,10 +461,13 @@ class EpomakerController:
             del th_cpu
 
             # Get device temperature using the provided key
-            if temp_key or test_mode:
+            if temp_key:
                 th_temp = TimeHelper(min_duration=1.6)
                 self.send_temperature(get_device_temp(temp_key, test_mode))
                 del th_temp
+            elif test_mode:
+                self.send_temperature(get_device_temp("dummy_device", test_mode))
+                time.sleep(1.6)
 
     def close_device(self) -> None:
         """Closes the USB HID device."""

--- a/src/epomakercontroller/utils/sensors.py
+++ b/src/epomakercontroller/utils/sensors.py
@@ -1,28 +1,43 @@
+from dataclasses import dataclass
 from typing import Any
 import psutil
 import random
 
 
 def get_cpu_usage(test_mode: bool = False) -> int:
+    """Get the current CPU usage.
+
+    Args:
+        test_mode (bool): If true, return a random int between 0 and 99.
+
+    Returns:
+        int: CPU usage, or a random number if `test_mode`.
+    """
     if test_mode:
         return random.randint(0, 99)
     return int(round(psutil.cpu_percent(interval=1)))
 
 
-def get_device_temp(temp_key: str | None, test_mode: bool = False) -> int | None:
+def get_device_temp(temp_key: str, test_mode: bool = False) -> int:
+    """Get the temperature of a device specified by `temp_key`, or 0 if the key cannot be found.
+
+    Args:
+        temp_key (str): Key corresponding to a device.
+        test_mode (bool): If true, return a random int between 0 and 99.
+
+    Returns:
+        int: The temperature of the device, 0 if not found, or a random number if `test_mode`.
+    """
     if test_mode:
         return random.randint(0, 99)
 
-    if not temp_key:
-        return None
-
-    temps = get_temp_devices()
+    temps = _get_temp_devices()
     if not temps:
         return 0
 
     if temp_key in temps:
-        cpu_temp = temps[temp_key][0].current
-        return int(round(cpu_temp))
+        device_temp = temps[temp_key]
+        return int(round(device_temp))
 
     else:
         available_keys = list(temps.keys())
@@ -36,25 +51,30 @@ def get_device_temp(temp_key: str | None, test_mode: bool = False) -> int | None
     return 0
 
 
-def get_temp_devices() -> Any:
+def _get_temp_devices() -> dict[str, float] | None:
     try:
-        return psutil.sensors_temperatures()
+        hw_temperatures = psutil.sensors_temperatures()
     except AttributeError:
         print("Temperature monitoring not supported on this system.")
+        return None
 
-    return None
+    temperature_sensors: dict[str, float] = {}
+    for device_name, entries in hw_temperatures.items():
+        for index, entry in enumerate(entries):
+            # A single device may have multiple sensors, need to be able
+            # to access each one
+            device_key = f"{device_name}-{index}"
+            temperature_sensors[device_key] = entry.current
+
+    return temperature_sensors
 
 
 def print_temp_devices() -> None:
-    temps = get_temp_devices()
+    temps = _get_temp_devices()
     if not temps:
         print("No temperature sensors found.")
         return
 
-    for key, entries in temps.items():
-        print(f"\nTemperature key: {key}")
-        for entry in entries:
-            print(f"  Label: {entry.label or 'N/A'}")
-            print(f"  Current: {entry.current}°C")
-            print(f"  High: {entry.high or 'N/A'}°C")
-            print(f"  Critical: {entry.critical or 'N/A'}°C")
+    print("{0:20} {1}".format("DEVICE KEY", "CURRENT TEMPERATURE"))
+    for device_key, temp in temps.items():
+        print("{0:20} {1}°C".format(device_key, temp))

--- a/src/epomakercontroller/utils/sensors.py
+++ b/src/epomakercontroller/utils/sensors.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-from typing import Any
 import psutil
 import random
 
@@ -70,6 +68,7 @@ def _get_temp_devices() -> dict[str, float] | None:
 
 
 def print_temp_devices() -> None:
+    """Print available temperature sensors by key and current temperature."""
     temps = _get_temp_devices()
     if not temps:
         print("No temperature sensors found.")


### PR DESCRIPTION
Change the way temperature sensors are addressed so that if some device has multiple sensors on it, they can each be addressed:

```
epomakercontroller list-temp-devices
DEVICE KEY                       CURRENT TEMPERATURE
acpitz-0                         59.0°C
nvme-0                           30.85°C
nvme-1                           43.85°C
nvme-2                           59.85°C
nvme-3                           30.85°C
pch_skylake-0                    34.0°C
coretemp-0                       58.0°C
coretemp-1                       47.0°C
coretemp-2                       57.0°C
coretemp-3                       46.0°C
coretemp-4                       44.0°C
iwlwifi_1-0                      33.0°C
```

Have also added support for getting nvidia gpu temperatures using a module called `gpustat`:
```
epomakercontroller start-daemon NVIDIA-GeForce-MX150-0
WARNING: If this program errors out or you cancel early, the keyboard
              may become unresponsive. It should work fine again if you unplug and plug
               it back in!
Using: 2025-05-02 17:47:28.576785
Sending CPU 3%
Sending temperature 34C
Sending CPU 1%
Sending temperature 34C
Sending CPU 1%
Sending temperature 34C
Sending CPU 6%
Sending temperature 33C
```

I have hopefully accounted for errors if no nvidia gpu is present (eg in the current docker container), the user should just get a message about no nvidia devices, but just continue on:
```
docker run epomaker-controller:latest list-temp-devices
Creating config directory at /home/nonrootuser/.epomaker-controller
Creating default config file at /home/nonrootuser/.epomaker-controller/config.json
No NVIDIA driver available: NVML Shared Library Not Found
DEVICE KEY              CURRENT TEMPERATURE
acpitz-0                48.0°C
nvme-0                  29.85°C
nvme-1                  39.85°C
nvme-2                  59.85°C
nvme-3                  29.85°C
pch_skylake-0           34.0°C
coretemp-0              46.0°C
coretemp-1              46.0°C
coretemp-2              46.0°C
coretemp-3              46.0°C
coretemp-4              45.0°C
iwlwifi_1-0             29.0°C
```

Related issue: https://github.com/strodgers/epomaker-controller/issues/50