### PR TITLE
Replaced old .gitignore with Python.gitignore. Kept IDE configs ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,8 +105,8 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-#poetry.toml
+poetry.lock
+poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.


### PR DESCRIPTION
[Python.gitignore](https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore)

This .gitignore should contain everything, that needs to be ignored in repository. I want to contribute with some code improvements and having .idea/ folder tracked is kinda inconvenient

Also I think there's no need to ignore .github directory, because otherwise you can't change your workflow scripts. Or I misunderstood something.