### PR TITLE
Finish up moving to python3.12

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         miniconda-version: "latest"
         auto-update-conda: true
-        python-version: 3.11
+        python-version: 3.12
         channels: conda-forge, defaults
 
     - name: Add conda to system path

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ sudo apt-get install python3-tkinter
 ```
 
 ## Installation
-I suggest using conda or a python virtual env, tested on python 3.10 and 3.12:
+I suggest using conda or a python virtual env with python 3.12:
 
 _Epomakercontroller_ package is available on [PyPi](https://pypi.org/project/EpomakerController/)
 
 ```console
-$ python3.10 -m venv epomaker
+$ python3.12 -m venv epomaker
 $ source epomaker/bin/activate
 $ pip install EpomakerController
 ```

--- a/environment-test.yml
+++ b/environment-test.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - python=3.11
+  - python=3.12
   - flake8
   - pytest
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11
+  - python=3.12
   - numpy
   - click
   - hidapi


### PR DESCRIPTION
Some small bits missed in https://github.com/strodgers/epomaker-controller/pull/67 for moving to python3.12