### PR TITLE
add support for Epomaker RT85

### DIFF
--- a/src/epomakercontroller/configs/default.json
+++ b/src/epomakercontroller/configs/default.json
@@ -2,7 +2,8 @@
     "VENDOR_ID": 12625,
     "PRODUCT_IDS_WIRED": [
         16400,
-        16405
+        16405,
+        20482
     ],
     "PRODUCT_IDS_24G": [
         16401,

--- a/tests/data/config/config.json
+++ b/tests/data/config/config.json
@@ -2,7 +2,8 @@
     "VENDOR_ID": 12625,
     "PRODUCT_IDS_WIRED": [
         16400,
-        16405
+        16405,
+        20482
     ],
     "PRODUCT_IDS_24G": [
         16401,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,7 @@ def test_default_main_config():
 
     DEFAULT_MAIN_CONFIG = {
         "VENDOR_ID": 0x3151,
-        "PRODUCT_IDS_WIRED": [0x4010, 0x4015],
+        "PRODUCT_IDS_WIRED": [0x4010, 0x4015, 0x5002],
         "PRODUCT_IDS_24G": [0x4011, 0x4016],
         "USE_WIRELESS": False,
         "DEVICE_DESCRIPTION_REGEX": "ROYUAN .* System Control",


### PR DESCRIPTION
The Epomaker RT85 utilizes the same 1.47" TFT mini-screen and underlying communication protocol as the RT100. Added the USB Product ID (0x5002 / 20482) to configuration and test files.