### PR TITLE
Add helper for image uploads while daemon is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ epomakercontroller start-daemon
 
 The daemon will also update the date and time once when it starts
 
+### Upload images while the daemon is running
+
+If you run the daemon as a systemd service, stop it before uploading an image and
+start it again afterwards. The helper script in `service/epomaker-upload-image`
+does this automatically:
+
+```console
+service/epomaker-upload-image path/to/image.png
+```
+
+By default it controls `epomaker-controller.service` and runs `epomakercontroller`
+from `PATH`. You can override both values if your service or command is named
+differently:
+
+```console
+EPOMAKER_SERVICE_NAME=my-epomaker.service EPOMAKER_CONTROLLER_BIN=/path/to/epomakercontroller service/epomaker-upload-image path/to/image.png
+```
+
 ### Show connected devices
 
 You can print all the available information about the connected keyboard using the 'dev'

--- a/service/epomaker-upload-image
+++ b/service/epomaker-upload-image
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${EPOMAKER_SERVICE_NAME:-epomaker-controller.service}"
+CONTROLLER_BIN="${EPOMAKER_CONTROLLER_BIN:-epomakercontroller}"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: epomaker-upload-image IMAGE_PATH" >&2
+  exit 2
+fi
+
+was_active=0
+if systemctl is-active --quiet "$SERVICE_NAME"; then
+  was_active=1
+  systemctl stop "$SERVICE_NAME"
+fi
+
+restart_service() {
+  if [[ "$was_active" -eq 1 ]]; then
+    systemctl start "$SERVICE_NAME"
+  fi
+}
+trap restart_service EXIT
+
+"$CONTROLLER_BIN" upload-image "$1"

--- a/tests/test_service_upload_helper.py
+++ b/tests/test_service_upload_helper.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_upload_helper_restarts_active_service(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "commands.log"
+    image_file = tmp_path / "image.png"
+    image_file.write_bytes(b"test")
+
+    systemctl = bin_dir / "systemctl"
+    systemctl.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo systemctl \"$@\" >> \"$HELPER_LOG\"\n"
+        "if [[ \"$1\" == \"is-active\" ]]; then exit 0; fi\n"
+    )
+    systemctl.chmod(0o755)
+
+    controller = bin_dir / "epomakercontroller"
+    controller.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo epomakercontroller \"$@\" >> \"$HELPER_LOG\"\n"
+    )
+    controller.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HELPER_LOG"] = str(log_file)
+
+    subprocess.run(
+        ["service/epomaker-upload-image", str(image_file)],
+        cwd=Path(__file__).parents[1],
+        env=env,
+        check=True,
+    )
+
+    assert log_file.read_text().splitlines() == [
+        "systemctl is-active --quiet epomaker-controller.service",
+        "systemctl stop epomaker-controller.service",
+        f"epomakercontroller upload-image {image_file}",
+        "systemctl start epomaker-controller.service",
+    ]


### PR DESCRIPTION
## Summary

  Adds a small helper script for Linux/systemd users who run the controller daemon as a service.

  When the daemon is running, uploading an image can leave the display in a state where CPU/temperature updates do
  not resume visibly until the daemon is restarted. The helper stops the service, uploads the image, and restarts the
  service only if it was active before.

  ## Usage

 The script should be run with permissions to stop/start the configured systemd service. For system services this
  may require polkit authorization or running the helper with appropriate privileges.

  ```console
  service/epomaker-upload-image path/to/image.png
```
  By default it uses:

  - service: epomaker-controller.service
  - command: epomakercontroller

  Both can be overridden:

  EPOMAKER_SERVICE_NAME=my-epomaker.service EPOMAKER_CONTROLLER_BIN=/path/to/epomakercontroller service/epomaker-
  upload-image path/to/image.png

  ## Testing

  python -m pytest tests/test_service_upload_helper.py

  Result:

  1 passed