### PR TITLE
Resolve config and temp paths independently of the working directory

### DIFF
--- a/src/epomakercontroller/configs/configs.py
+++ b/src/epomakercontroller/configs/configs.py
@@ -65,9 +65,7 @@ class Config:
 
 
 def get_main_config_directory() -> Path:
-    home_dir = Path(os.path.abspath(os.curdir))
-    config_dir = home_dir / CONFIG_DIRECTORY
-    return config_dir
+    return Path(CONFIG_DIRECTORY)
 
 
 def create_default_main_config(config_file: Path) -> None:

--- a/src/epomakercontroller/configs/constants.py
+++ b/src/epomakercontroller/configs/constants.py
@@ -2,9 +2,26 @@
 and provide a single point of project configuration
 """
 import os
+import tempfile
 
 
-CONFIG_DIRECTORY = ".epomaker-controller"
+# Where user config is written.
+#
+# True  -- the user's config directory ($XDG_CONFIG_HOME, else ~/.config).
+# False -- alongside the installed package.
+#
+# Note that on a pip or distro install the package directory is usually
+# root-owned, is replaced on upgrade, and is shared between users, so False
+# means config may fail to save, be lost on update, or collide.
+USE_XDG_CONFIG_DIR = True
+
+if USE_XDG_CONFIG_DIR:
+    CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+        os.path.expanduser("~"), ".config"
+    )
+    CONFIG_DIRECTORY = os.path.join(CONFIG_HOME, "epomaker-controller")
+else:
+    CONFIG_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 CONFIG_NAME = "config.json"
 
 # OS dependent path
@@ -15,7 +32,7 @@ if os.name == "nt":
     if not os.path.exists(ROOT_FOLDER):
         os.mkdir(ROOT_FOLDER)
 
-TMP_FOLDER = os.path.abspath("./.epomaker_controller")
+TMP_FOLDER = os.path.join(tempfile.gettempdir(), "epomaker_controller")
 ETC_FOLDER = os.path.abspath(ROOT_FOLDER + "etc/")
 
 # Create folder on Windows
@@ -23,12 +40,10 @@ if os.name == "nt":
     if not os.path.exists(ETC_FOLDER):
         os.mkdir(ETC_FOLDER)
 
-# Create temp folder in project path on Linux as well
-if not os.path.exists(TMP_FOLDER):
-    os.mkdir(TMP_FOLDER)
-
 RULE_FILE_PATH = ETC_FOLDER + "/udev/rules.d/99-epomaker-rt100.rules"
 TMP_FILE_PATH = TMP_FOLDER + "/99-epomaker-rt100.rules"
-PATH_TO_DEFAULT_CONFIG = "src/epomakercontroller/configs/default.json"
+PATH_TO_DEFAULT_CONFIG = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "default.json"
+)
 
 DAEMON_TIME_DELAY = 1.6

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -204,6 +204,7 @@ class EpomakerController(ControllerBase):
 
         # Write the rule to a temporary file
         temp_file_path = TMP_FILE_PATH
+        os.makedirs(os.path.dirname(temp_file_path), exist_ok=True)
 
         with open(temp_file_path, "w", encoding="utf-8") as temp_file:
             temp_file.write(rule_content)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,9 +1,31 @@
 import os
+
 from epomakercontroller.configs import constants
 
 
-def test_validate_path():
-    """Add other validation here if path should exist on controller startup"""
+def test_default_config_is_bundled():
+    """The default config ships with the package, so it must always be readable.
 
-    assert os.path.exists(constants.TMP_FOLDER), "Temp folder does not exist"
-    assert os.path.exists(constants.PATH_TO_DEFAULT_CONFIG), "Default config path does not exist"
+    Resolved against constants.py rather than the working directory: the old
+    relative path only existed inside a source checkout, so an installed copy
+    raised FileNotFoundError anywhere else.
+    """
+    assert os.path.isabs(constants.PATH_TO_DEFAULT_CONFIG)
+    assert os.path.exists(
+        constants.PATH_TO_DEFAULT_CONFIG
+    ), "Default config path does not exist"
+
+
+def test_writable_paths_are_absolute():
+    """Paths written to must not depend on the working directory.
+
+    These are deliberately NOT asserted to exist: importing a module should not
+    create directories. They are created by the code that writes to them.
+    """
+    for path in (constants.CONFIG_DIRECTORY, constants.TMP_FOLDER):
+        assert os.path.isabs(path), f"{path} is not absolute"
+
+    if constants.USE_XDG_CONFIG_DIR:
+        assert not constants.CONFIG_DIRECTORY.startswith(
+            os.path.dirname(os.path.abspath(constants.__file__))
+        ), "With USE_XDG_CONFIG_DIR, config must live outside the package"


### PR DESCRIPTION
Three related paths in `configs/constants.py` resolve against the current working directory, so an installed copy only works when run from a source checkout.

**1. `PATH_TO_DEFAULT_CONFIG` cannot be found after install**

```python
PATH_TO_DEFAULT_CONFIG = "src/epomakercontroller/configs/default.json"
```

That path only exists inside a checkout. From anywhere else:

```
$ cd ~ && python -c "from epomakercontroller.configs.configs import load_main_config; load_main_config()"
FileNotFoundError: [Errno 2] No such file or directory: 'src/epomakercontroller/configs/default.json'
```

This affects any desktop launcher or systemd service, where the working directory is the home directory. Now resolved against `__file__`, where the file is actually installed.

**2. The config directory follows the working directory**

```python
def get_main_config_directory() -> Path:
    home_dir = Path(os.path.abspath(os.curdir))
```

The variable is named `home_dir` but holds `os.curdir`, so each working directory gets its own `.epomaker-controller/`. 0.0.8 used `Path.home()`; restored.

**3. `constants.py` creates a directory at import time**

```python
TMP_FOLDER = os.path.abspath("./.epomaker_controller")
...
if not os.path.exists(TMP_FOLDER):
    os.mkdir(TMP_FOLDER)
```

Importing the package creates a directory in the caller's working directory. Moved under `tempfile.gettempdir()`, and created by `generate_udev_rule()` — the only thing that writes there — so behaviour is unchanged.

Found while building a GTK front end against 0.0.9; I currently patch these at import to make a systemd user service work.