### PR TITLE
Make the HID interface selectable, defaulting away from interface 0

### DIFF
--- a/src/epomakercontroller/cli.py
+++ b/src/epomakercontroller/cli.py
@@ -34,8 +34,17 @@ def wrapped_command(func):
 
 @click.group()
 @click.version_option(retrieve_app_version(), prog_name="EpomakerController")
-def cli() -> None:
+@click.option(
+    "--interface",
+    type=int,
+    default=None,
+    help="HID interface to open, overriding INTERFACE in config.json. "
+         "Try another value if the keyboard misbehaves while a command runs.",
+)
+def cli(interface: int | None) -> None:
     """A simple CLI for the EpomakerController."""
+    if interface is not None:
+        CONFIG_MAIN.data["INTERFACE"] = interface
 
 
 @cli.command()

--- a/src/epomakercontroller/configs/default.json
+++ b/src/epomakercontroller/configs/default.json
@@ -10,6 +10,7 @@
         16406
     ],
     "USE_WIRELESS": false,
+    "INTERFACE": 1,
     "DEVICE_DESCRIPTION_REGEX": "ROYUAN .* System Control",
     "CONF_LAYOUT_PATH": "EpomakerRT100-UK-ISO.json",
     "CONF_KEYMAP_PATH": "EpomakerRT100.json"

--- a/src/epomakercontroller/epomakercontroller.py
+++ b/src/epomakercontroller/epomakercontroller.py
@@ -58,6 +58,10 @@ class EpomakerConfig:
 
         self.vendor_id = config_main["VENDOR_ID"]
         self.use_wireless = config_main["USE_WIRELESS"]
+        # Which HID interface to open. None falls back to opening by
+        # vendor/product id, which takes whichever the backend enumerates
+        # first -- on Windows that is the only option available.
+        self.interface: Optional[int] = config_main["INTERFACE"]
 
         self.product_ids: list[int] = (
             config_main["PRODUCT_IDS_WIRED"]
@@ -170,6 +174,26 @@ class EpomakerController(ControllerBase):
 
         return None
 
+    def _find_interface_path(self, product_id: int) -> Optional[bytes]:
+        """Path of the configured HID interface, or None to open by id.
+
+        Returns None when no interface is configured, or when the backend does
+        not report interface numbers -- notably on Windows, where hidapi
+        reports -1 and opening by vendor/product id is the only option.
+        """
+        if self.config.interface is None:
+            return None
+
+        for entry in hid.enumerate(self.config.vendor_id, product_id):
+            if entry.get("interface_number") == self.config.interface:
+                return entry["path"]
+
+        Logger.log_warning(
+            f"Interface {self.config.interface} not found on device "
+            f"{self.config.vendor_id:04x}:{product_id:04x}, opening by id instead"
+        )
+        return None
+
     def _open_device(self, product_id: int) -> None:
         """Opens the USB HID device.
 
@@ -177,7 +201,11 @@ class EpomakerController(ControllerBase):
             product_id (int): The product ID.
         """
         try:
-            self.device.open(self.config.vendor_id, product_id)
+            path = self._find_interface_path(product_id)
+            if path is not None:
+                self.device.open_path(path)
+            else:
+                self.device.open(self.config.vendor_id, product_id)
         except IOError as e:
             Logger.log_error(
                 f"Failed to open device: {e}\n"

--- a/tests/data/config/config.json
+++ b/tests/data/config/config.json
@@ -10,6 +10,7 @@
         16406
     ],
     "USE_WIRELESS": false,
+    "INTERFACE": 1,
     "DEVICE_DESCRIPTION_REGEX": "ROYUAN .* System Control",
     "CONF_LAYOUT_PATH": "EpomakerRT100-UK-ISO.json",
     "CONF_KEYMAP_PATH": "EpomakerRT100.json"


### PR DESCRIPTION
Follows #94 — thanks for the context about the unfinished Windows work, that shaped how this is built.

`_open_device()` opens by vendor/product id, taking whichever interface enumerates first. On an RT100 that's interface 0, the one the README warns interferes with typing. 0.0.8 avoided it via the `DEVICE_DESCRIPTION_REGEX` lookup, which landed on interface 1; that lookup went away in 0.0.9.

Adds an `INTERFACE` config key defaulting to `1`, restoring the pre-0.0.9 behaviour rather than picking a new number. Setting it to `null` falls back to opening by id — which is what Windows needs, since hidapi reports `interface_number` as `-1` there. A configured interface that isn't present logs a warning and falls back rather than failing.

The second commit is optional. While testing the first, it became clear the correct interface is device-specific and editing `config.json` to try one is awkward — so it exposes the same setting as `--interface`. It wasn't part of what we discussed and came out of doing the work. It's a separate commit so it's easy to ignore; say the word and I'll drop it.

On my RT100 (`3151:4010`): interface 0 is the keyboard, 1 carries Consumer Control — holding it takes the volume knob and media keys offline until released — and 2 has no input collections at all. So 2 may suit `start-daemon` better, since that holds the device continuously. That's one board though, which is why the default restores 0.0.8's behaviour rather than generalising from mine.